### PR TITLE
use handler.service_type instead of digging into config

### DIFF
--- a/app/jobs/process_job.rb
+++ b/app/jobs/process_job.rb
@@ -73,7 +73,7 @@ class ProcessJob < ApplicationJob
           else
             rus.add(row: row_num, row_occ: row_occ, rec_id: id)
 
-            if handler.mapper[:config][:service_type] == 'relation'
+            if handler.service_type == 'relation'
               rep.append({ row: row_num,
                            row_occ: row_occ,
                            header: 'INFO: relationship id',

--- a/app/services/record_transfer_service.rb
+++ b/app/services/record_transfer_service.rb
@@ -23,7 +23,7 @@ class RecordTransferService
     @batch = transfer.batch
     @client = @batch.connection.client
     mapper = get_mapper
-    @service_type = mapper['config']['service_type']
+    @service_type = transfer.batch.handler.service_type
     @type = mapper['config']['service_path']
     @subtype = mapper['config']['authority_subtype']
   end


### PR DESCRIPTION
`cspace-batch-import` should not have to know about the internals of
the mapper structure. `collectionspace-mapper` is already all up in
the mapper structure and should be able to tell the importer what it
needs to know cleanly through the DataHandler interface.

`RecordTransferService` still has a couple of mapper excavations to
get rid of, but they are not immediate problems, so they'll be on the
list for later improvements