### PR TITLE
Gh97 cannot create new batch

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -59,7 +59,7 @@ class BatchesController < ApplicationController
         continue = true
       else
         @batch.destroy # scrap it, they'll have to start over
-        flash[:csv_lint] = validator.errors.take(5)
+        flash[:csv_lint] = true
       end
     end
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -4,8 +4,7 @@ class Batch < ApplicationRecord
   include WorkflowManager
   CONTENT_TYPES = [
     'application/vnd.ms-excel',
-    'text/csv',
-    'text/plain'
+    'text/csv'
   ].freeze
   has_one_attached :spreadsheet
   has_one :step_preprocess, class_name: 'Step::Preprocess', dependent: :destroy

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -4,7 +4,8 @@ class Batch < ApplicationRecord
   include WorkflowManager
   CONTENT_TYPES = [
     'application/vnd.ms-excel',
-    'text/csv'
+    'text/csv',
+    'text/plain'
   ].freeze
   has_one_attached :spreadsheet
   has_one :step_preprocess, class_name: 'Step::Preprocess', dependent: :destroy

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -96,32 +96,10 @@
 <% if flash[:csv_lint] %>
   <article class="flash message is-danger is-small mt-3">
     <div class="message-header">
-      <p>Prescreening uploaded CSV errors were found (displaying up to first 5)</p>
+      <p>Uploaded CSV is invalid</p>
     </div>
     <div class="message-body">
-      <table class="table is-fullwidth is-bordered">
-        <thead>
-          <tr>
-            <td class="has-text-weight-bold">Row</th>
-            <td class="has-text-weight-bold">Category</th>
-            <td class="has-text-weight-bold">Type</th>
-            <td class="has-text-weight-bold">Column</th>
-            <td class="has-text-weight-bold">Content</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% flash[:csv_lint].each do |error| %>
-            <tr>
-              <td><%= error.row %></td>
-              <td><%= error.category %></td>
-              <td><%= error.type %></td>
-              <td><%= error.column %></td>
-              <td><%= truncate error.content.to_s, length: 100 %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-      <p class="content">These errors will be lost on page reload</p>
+      <p class="content">Please upload and validate your file at <a>https://csvlint.io/</a>, fix any issues that tool finds, and then try again.</p>
     </div>
   </article>
 <% end %>


### PR DESCRIPTION
Closes #97 

Well, it doesn't really fix the problem in #97 which is an invalid/badly structured CSV file. 

This tool is not a magical CSV structure fixing tool, so it can't fix that. 

This fixes the issue where the app was falling over when form template flash shown when the CSV fails initial validation was sent a *string* of the `Csvlint::ErrorMessage` instead of the actual object. (The error message, etc. is over at #97)

It eliminates showing the first 5 errors and instead instructs the user to take their CSV over to https://csvlint.io/ and remediate their CSV.

The `Csvlint::ErrorMessage` had `@category=:structure` and `@type=:unknown_error`. The webapp actually gives usable info (but unfortunately, its "Download Standardised CSV" button did NOT magically fix the issue).