### PR TITLE
use collectionspace-mapper v2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'aws-sdk-s3', require: false
 gem 'bulma-rails', '~> 0.9.0'
 gem 'collectionspace-client', tag: 'v0.10.0', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v0.7.7', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v2.4.9', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v2.5.0', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 gem 'csvlint'
 gem 'devise'
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: fa7145db2f65297cdbdb2241b4f7bc085c4f9077
-  tag: v2.4.9
+  revision: 92bf74ed834a11acb986d5f1f252b50f6c56e99c
+  tag: v2.5.0
   specs:
-    collectionspace-mapper (2.4.9)
+    collectionspace-mapper (2.5.0)
       chronic
       facets
       nokogiri (>= 1.10.9)


### PR DESCRIPTION
This release fixes an annoying spurious warning about unknown option
list values, and adds a batch config option needed from migration work.