### PR TITLE
Fix URI.escape warning

### DIFF
--- a/app/services/record_transfer_service.rb
+++ b/app/services/record_transfer_service.rb
@@ -53,7 +53,7 @@ class RecordTransferService
 
     return {} if data['bloburi'].blank?
 
-    { query: { 'blobUri' => URI.encode(data['bloburi']) } }
+    { query: { 'blobUri' => URI(data['bloburi']) } }
   end
 
 


### PR DESCRIPTION
Follow example [here](https://ruby-doc.org/stdlib-2.7.4/libdoc/uri/rdoc/URI.html) instead of using `URI.encode`.

Closes #131 

See also: https://bugs.ruby-lang.org/issues/16469 (This is warning
about `URI.encode`, though the message is for `URI.escape`