### PR TITLE
Attach report files to step as job running

### DIFF
--- a/app/models/concerns/workflow_manager.rb
+++ b/app/models/concerns/workflow_manager.rb
@@ -24,7 +24,7 @@ module WorkflowManager
 
     # we transitioned beyond run!
     def ran?
-      failed? || finished?
+      cancelled? || failed? || finished?
     end
 
     aasm(:step, column: 'step_state') do

--- a/app/services/step_manager_service.rb
+++ b/app/services/step_manager_service.rb
@@ -46,18 +46,26 @@ class StepManagerService
     step.batch.failed! if error_on_warning && !step.batch.failed?
   end
 
-  def attach!
+  def attach!(force: false)
+    return unless force || step.checkin?
+
     step.update(messages: messages.uniq)
     return if files.empty?
 
+    step.reports.purge
     files.each do |f|
       next if f[:type] == :tmp
 
-      step.reports.attach(
-        io: File.open(f[:file]),
-        filename: File.basename(f[:file]),
-        content_type: f[:content_type]
-      )
+      begin
+        step.reports.attach(
+          io: File.open(f[:file]),
+          filename: File.basename(f[:file]),
+          content_type: f[:content_type]
+        )
+      rescue StandardError
+        # only when attachment fails while forced (suppressed incrementally)
+        add_message("Error attaching file: #{File.basename(f[:file])}") if force
+      end
     end
   end
 
@@ -198,7 +206,7 @@ class StepManagerService
   def finishup!
     step.update(completed_at: Time.now.utc)
     step.update_header # broadcast final status of step
-    attach!
+    attach!(force: true)
     remove_tmp_files!
     step.update_progress(force: true)
   end
@@ -262,6 +270,7 @@ class StepManagerService
 
         nudge! if type == :initial
         yield row.to_hash
+        attach! # add / update files incrementally
       rescue CSV::MalformedCSVError => e
         add_error!
         log!('error', e.message)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,7 +75,7 @@ en:
     name: Name
     batch_config: Config
     step:
-      catastrophe: The job failed with an unexpected error during processing
+      catastrophe: The job failed with an unexpected error during processing. Please note that any attached reports may be incomplete and not represent all of the activity that was performed while the job was running.
       completed_at: "%{step} was completed at %{completed_at}"
       files: Files
       archive:


### PR DESCRIPTION
If a Sidekiq process fails currently all record of the job activity
is lost. By attaching the files incrementally while the job is
running we can provide the user with the reports near to the point
of failure (near because we are not attaching for every row
processed but along with the checkin point for status updates).

The checkin point may need to become configurable.