### PR TITLE
bump collectionspace-mapper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@ gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.10.0', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v0.7.7', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v2.5.1', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v2.5.2', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+
 gem 'csvlint'
 gem 'devise'
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: d05248f384d9686a9bfa1a79ef4f89c6d67bcc82
-  tag: v2.5.1
+  revision: ed43713db46cbc593318ded2b2d6afb6c61be848
+  tag: v2.5.2
   specs:
-    collectionspace-mapper (2.5.1)
+    collectionspace-mapper (2.5.2)
       chronic
       facets
       memo_wise (~> 1.1.0)


### PR DESCRIPTION
The new version adds an option necessary for clients to update existing records that may have leading/trailing spaces in the record ID field: 

https://github.com/collectionspace/collectionspace-mapper/releases/tag/v2.5.2