### PR TITLE
Disable ActiveStorage content inspection

### DIFF
--- a/app/models/mapper.rb
+++ b/app/models/mapper.rb
@@ -20,7 +20,8 @@ class Mapper < ApplicationRecord
     config.attach(
       io: StringIO.new(HTTP.get(url).to_s),
       filename: "#{title}.json",
-      content_type: 'application/json'
+      content_type: 'application/json',
+      identify: false
     )
     self.status = true
   end

--- a/app/services/step_manager_service.rb
+++ b/app/services/step_manager_service.rb
@@ -60,7 +60,8 @@ class StepManagerService
         step.reports.attach(
           io: File.open(f[:file]),
           filename: File.basename(f[:file]),
-          content_type: f[:content_type]
+          content_type: f[:content_type],
+          identify: false
         )
       rescue StandardError
         # only when attachment fails while forced (suppressed incrementally)

--- a/test/controllers/step/preprocesses_controller_test.rb
+++ b/test/controllers/step/preprocesses_controller_test.rb
@@ -14,7 +14,8 @@ module Step
       @batch.mapper.config.attach(
         io: File.open(Rails.root.join('test', 'fixtures', 'files', 'core-cataloging.json')),
         filename: 'core-cataloging.json',
-        content_type: 'application/json'
+        content_type: 'application/json',
+        identify: false
       )
       # @valid_params = {
       #   step_preprocess: {

--- a/test/job_helper.rb
+++ b/test/job_helper.rb
@@ -5,7 +5,8 @@ module JobHelper
     step.batch.spreadsheet.attach(
       io: File.open(Rails.root.join('test', 'fixtures', 'files', spreadsheet)),
       filename: spreadsheet,
-      content_type: 'text/csv'
+      content_type: 'text/csv',
+      identify: false
     )
   end
 
@@ -13,7 +14,8 @@ module JobHelper
     step.batch.mapper.config.attach(
       io: File.open(Rails.root.join('test', 'fixtures', 'files', mapper)),
       filename: mapper,
-      content_type: 'application/json'
+      content_type: 'application/json',
+      identify: false
     )
   end
 end


### PR DESCRIPTION
As we're always specifying the content type we don't need AS to do
this for us, and it's actually a problem in some cases (like when
a csv report contains embedded html).