### PR TITLE
Revert "changes related to migration tooling"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,9 @@ gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'
 gem 'aws-sdk-s3', require: false
 gem 'bulma-rails', '~> 0.9.0'
 
-gem 'collectionspace-client', tag: 'v0.14.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
-gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v4.0.1', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-client', tag: 'v0.10.0', git: 'https://github.com/collectionspace/collectionspace-client.git'
+gem 'collectionspace-refcache', tag: 'v0.7.7', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
+gem 'collectionspace-mapper', tag: 'v3.0.0', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 
 gem 'csvlint'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,31 @@
 GIT
   remote: https://github.com/collectionspace/collectionspace-client.git
-  revision: b1240d71ca95085ece7b3d1f2f067b538ab9eb2f
-  tag: v0.14.1
+  revision: b33bbe14b237283699f74fee319ed0b996950ce8
+  tag: v0.10.0
   specs:
-    collectionspace-client (0.14.1)
+    collectionspace-client (0.10.0)
       httparty
       json
       nokogiri
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: a79c700f8bff3d3eef9f95fee7f3ee93c7873f22
-  tag: v4.0.1
+  revision: 7ee69747be0865686d33b872bb038fa39d3baf51
+  tag: v3.0.0
   specs:
-    collectionspace-mapper (4.0.1)
+    collectionspace-mapper (3.0.0)
       chronic
-      dry-configurable (~> 0.14)
       facets
       memo_wise (~> 1.1.0)
-      nokogiri (~> 1.13.3)
+      nokogiri (>= 1.10.9)
       xxhash (>= 0.4.0)
-      zeitwerk (~> 2.5)
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-refcache.git
-  revision: ade17428230a7b3d3d05d7384975d71bc866711f
-  tag: v1.0.0
+  revision: 25194130156f4d92bb795bbf1227cf792e906726
+  tag: v0.7.7
   specs:
-    collectionspace-refcache (1.0.0)
+    collectionspace-refcache (0.7.7)
       redis (~> 4.2.1)
       zache (~> 0.12.0)
 
@@ -173,11 +171,6 @@ GEM
       warden (~> 1.2.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dry-configurable (0.15.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 0.6)
-    dry-core (0.7.1)
-      concurrent-ruby (~> 1.0)
     e2mmap (0.1.0)
     erubi (1.10.0)
     escape_utils (1.2.1)

--- a/README.md
+++ b/README.md
@@ -78,14 +78,11 @@ Environment:
 
 The `REDIS_URL` can be set on a per cache basis using:
 
-- REDIS_CABLE_URL # (1) websockets
-- REDIS_CACHE_URL # (0) rails cache 
-- REDIS_CSIDCACHE_URL # (5) csidcache - (CSID lookup for searching for relations, via `CollectionSpace::RefCache`)
-- REDIS_REFCACHE_URL # (3) refcache - (refname lookup for authority and vocabulary terms, via `CollectionSpace::RefCache`)
-- REDIS_SESSION_URL # (4) rails sessions
-- REDIS_SIDEKIQ_URL # (2) background jobs
-
-The numbers in parentheses indicate the Redis database used by default in the Redis URL
+- REDIS_CABLE_URL # websockets
+- REDIS_CACHE_URL # rails cache
+- REDIS_REFCACHE_URL # refcache
+- REDIS_SESSION_URL # rails sessions
+- REDIS_SIDEKIQ_URL # background jobs
 
 For development only:
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -50,11 +50,7 @@ class Batch < ApplicationRecord
   def handler
     @rm ||= fetch_mapper
     CollectionSpace::Mapper::DataHandler.new(
-      record_mapper: @rm,
-      client: connection.client,
-      cache: connection.refcache,
-      csid_cache: connection.csidcache,
-      config: batch_config
+      record_mapper: @rm, client: connection.client, cache: connection.refcache, config: batch_config
     )
   end
 

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -40,22 +40,17 @@ class Connection < ApplicationRecord
     primary
   end
 
-  def csidcache
-    @csidcache_config ||= {
-      redis: Rails.configuration.csidcache_url,
-      domain: client.config.base_uri,
-      lifetime: 5 * 60
-    }
-    CollectionSpace::RefCache.new(config: @csidcache_config)
-  end
-  
   def refcache
     @cache_config ||= {
       redis: Rails.configuration.refcache_url,
       domain: client.config.base_uri,
-      lifetime: 5 * 60
+      error_if_not_found: false,
+      lifetime: 5 * 60,
+      search_delay: 5 * 60,
+      search_enabled: true,
+      search_identifiers: false
     }
-    CollectionSpace::RefCache.new(config: @cache_config)
+    CollectionSpace::RefCache.new(config: @cache_config, client: client)
   end
 
   def unset_primary

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,10 +36,6 @@ module CollectionSpaceCsvImporter
       ENV.fetch('REDIS_URL', 'redis://localhost:6379/3')
     end
 
-    config.csidcache_url = ENV.fetch('REDIS_CSIDCACHE_URL') do
-      ENV.fetch('REDIS_URL', 'redis://localhost:6379/5')
-    end
-
     config.superuser_email = ENV.fetch(
       'SUPERUSER_EMAIL', 'superuser@collectionspace.org'
     )

--- a/test/models/connection_test.rb
+++ b/test/models/connection_test.rb
@@ -58,13 +58,4 @@ class ConnectionTest < ActiveSupport::TestCase
     assert_not(c1.primary?)
     assert(c2.primary?)
   end
-
-  test 'can return RefCache and CSIDCache on two different Redis DBs' do
-    conn = connections(:core_superuser)
-    refcache = conn.refcache
-    assert(refcache.is_a?(CollectionSpace::RefCache))
-    csidcache = conn.csidcache
-    assert(csidcache.is_a?(CollectionSpace::RefCache))
-    assert(csidcache.config[:redis] != refcache.config[:redis])
-  end
 end


### PR DESCRIPTION
Reverts collectionspace/collectionspace-csv-importer#156

Incompatibility between Zeitwerk in Mapper and Rails production mode (eager loading enabled). Can be found with:

```
./bin/rails zeitwerk:check
```

Or run development with `config.eager_load = true`

Some related~ish looking info (but haven't had time to read through it):

- https://makandracards.com/makandra/498915-heads-up-byebug-has-problems-with-zeitwerk
- https://github.com/deivid-rodriguez/byebug/issues/564
- https://github.com/ruby/debug/issues/408
