### PR TITLE
bump mapper version to fix zeitwerk problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.14.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v4.0.1', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v4.0.2', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 
 gem 'csvlint'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: a79c700f8bff3d3eef9f95fee7f3ee93c7873f22
-  tag: v4.0.1
+  revision: dca7ffb36794681ef56525b9d7e2de4e2278d3fe
+  tag: v4.0.2
   specs:
-    collectionspace-mapper (4.0.1)
+    collectionspace-mapper (4.0.2)
       chronic
       dry-configurable (~> 0.14)
       facets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/collectionspace/collectionspace-client.git
-  revision: b33bbe14b237283699f74fee319ed0b996950ce8
-  tag: v0.10.0
+  revision: b1240d71ca95085ece7b3d1f2f067b538ab9eb2f
+  tag: v0.14.1
   specs:
-    collectionspace-client (0.10.0)
+    collectionspace-client (0.14.1)
       httparty
       json
       nokogiri
@@ -22,10 +22,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-refcache.git
-  revision: 25194130156f4d92bb795bbf1227cf792e906726
-  tag: v0.7.7
+  revision: ade17428230a7b3d3d05d7384975d71bc866711f
+  tag: v1.0.0
   specs:
-    collectionspace-refcache (0.7.7)
+    collectionspace-refcache (1.0.0)
       redis (~> 4.2.1)
       zache (~> 0.12.0)
 
@@ -208,7 +208,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.1)
-    json (2.6.1)
+    json (2.6.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)

--- a/README.md
+++ b/README.md
@@ -78,11 +78,14 @@ Environment:
 
 The `REDIS_URL` can be set on a per cache basis using:
 
-- REDIS_CABLE_URL # websockets
-- REDIS_CACHE_URL # rails cache
-- REDIS_REFCACHE_URL # refcache
-- REDIS_SESSION_URL # rails sessions
-- REDIS_SIDEKIQ_URL # background jobs
+- REDIS_CABLE_URL # (1) websockets
+- REDIS_CACHE_URL # (0) rails cache 
+- REDIS_CSIDCACHE_URL # (5) csidcache - (CSID lookup for searching for relations, via `CollectionSpace::RefCache`)
+- REDIS_REFCACHE_URL # (3) refcache - (refname lookup for authority and vocabulary terms, via `CollectionSpace::RefCache`)
+- REDIS_SESSION_URL # (4) rails sessions
+- REDIS_SIDEKIQ_URL # (2) background jobs
+
+The numbers in parentheses indicate the Redis database used by default in the Redis URL
 
 For development only:
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -50,7 +50,11 @@ class Batch < ApplicationRecord
   def handler
     @rm ||= fetch_mapper
     CollectionSpace::Mapper::DataHandler.new(
-      record_mapper: @rm, client: connection.client, cache: connection.refcache, config: batch_config
+      record_mapper: @rm,
+      client: connection.client,
+      cache: connection.refcache,
+      csid_cache: connection.csidcache,
+      config: batch_config
     )
   end
 

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -40,17 +40,22 @@ class Connection < ApplicationRecord
     primary
   end
 
+  def csidcache
+    @csidcache_config ||= {
+      redis: Rails.configuration.csidcache_url,
+      domain: client.config.base_uri,
+      lifetime: 5 * 60,
+    }
+    CollectionSpace::RefCache.new(config: @csidcache_config)
+  end
+  
   def refcache
     @cache_config ||= {
       redis: Rails.configuration.refcache_url,
       domain: client.config.base_uri,
-      error_if_not_found: false,
       lifetime: 5 * 60,
-      search_delay: 5 * 60,
-      search_enabled: true,
-      search_identifiers: false
     }
-    CollectionSpace::RefCache.new(config: @cache_config, client: client)
+    CollectionSpace::RefCache.new(config: @cache_config)
   end
 
   def unset_primary

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,10 @@ module CollectionSpaceCsvImporter
       ENV.fetch('REDIS_URL', 'redis://localhost:6379/3')
     end
 
+    config.csidcache_url = ENV.fetch('REDIS_CSIDCACHE_URL') do
+      ENV.fetch('REDIS_URL', 'redis://localhost:6379/5')
+    end
+
     config.superuser_email = ENV.fetch(
       'SUPERUSER_EMAIL', 'superuser@collectionspace.org'
     )

--- a/test/models/connection_test.rb
+++ b/test/models/connection_test.rb
@@ -58,4 +58,13 @@ class ConnectionTest < ActiveSupport::TestCase
     assert_not(c1.primary?)
     assert(c2.primary?)
   end
+
+  test 'can return RefCache and CSIDCache on two different Redis DBs' do
+    conn = connections(:core_superuser)
+    refcache = conn.refcache
+    assert(refcache.is_a?(CollectionSpace::RefCache))
+    csidcache = conn.csidcache
+    assert(csidcache.is_a?(CollectionSpace::RefCache))
+    assert(csidcache.config[:redis] != refcache.config[:redis])
+  end
 end


### PR DESCRIPTION
- eager load collectionspace-mapper to pass `zeitwerk:check` (as per [statement from zeitwerk maintainer](https://github.com/ruby/debug/issues/408#issuecomment-985989827))
- Initialize `CollectionSpace::Mapper::DataHandler` with a client-less RefCache
- Add `csid_cache` parameter to constructor for `CollectionSpace::Mapper::DataHandler` -- Since the only way to search for relations is by subject/object CSID, we need a way to efficiently look up CSIDs. Since I'm already setting up `collectionspace-mapper` to work with two separate `CollectionSpace::RefCache` instances for migration tooling stuff---one for refnames for terms, and one for CSIDs---it is much more straightforward to just make it always use two separate RefCaches for these two separate types of information. When `CollectionSpace::Mapper` is used with the default batch config by `collectionspace-csv-importer`, the CSID RefCache will only be used for looking up CSIDs to use in constructing searches for relations (required to determine the status of a given relation in the system). 