### PR TITLE
Update Delete Group functionality, resolves #168

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -22,8 +22,21 @@ class Group < ApplicationRecord
   end
 
   before_destroy do
-    Affiliation.where(group: self).destroy_all
-    User.where(group: self).destroy_all
+    assigned_users.each do |user|
+      if user.groups.count > 1 # the user has at least 1 other group
+        user.groups.delete self
+        user.update(group: user.groups.first)
+      end
+    end
+
+    [Affiliation, Connection, User].each do |model|
+      model.where(group: self).destroy_all
+    end
+  end
+
+  # an assigned user is one that has currently selected this group
+  def assigned_users
+    users.where(group: self)
   end
 
   def default?

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -64,6 +64,29 @@
         </div>
       </div>
     <% end %>
+
+    <hr/>
+    <h2 class="subtitle">
+      <%= t('users') %>
+    </h2>
+
+    <table class="table is-fullwidth is-hoverable">
+      <thead>
+        <tr>
+          <th><%= t 'user.name' %></th>
+          <th><%= t 'user.role' %></th>
+          <th><%= t 'user.enabled' %></th>
+          <th><%= t 'user.connections' %></th>
+          <th colspan="1"></th>
+      </thead>
+
+      <tbody>
+        <%= render partial: 'users',
+            collection: group.assigned_users,
+            as: :user
+        %>
+      </tbody>
+    </table>
   </div>
   <div class="column">
     <%= render partial: 'field_definitions' %>

--- a/app/views/groups/_users.html.erb
+++ b/app/views/groups/_users.html.erb
@@ -1,0 +1,44 @@
+<tr id="<%= dom_id(user) %>" data-user-id="<%= user.id %>">
+  <td>
+    <% if manage?(user) && !user.superuser? %>
+      <%= link_to edit_user_path(user) do %>
+        <%= render partial: 'users/user', locals: { icon: 'pencil', user: user } %>
+      <% end %>
+    <% else %>
+      <%= render partial: 'users/user', locals: { icon: 'user', user: user } %>
+    <% end %>
+  </td>
+  <td><%= user.role.name %></td>
+  <td>
+    <% if user.enabled? %>
+      <%= render partial: 'shared/icon',
+          locals: { classes: 'has-text-success', icon: 'thumbs-up' }
+      %>
+    <% else %>
+      <%= render partial: 'shared/icon',
+          locals: { classes: 'has-text-danger', icon: 'ban' }
+      %>
+    <% end %>
+    <% if can_toggle_status?(user) %>
+      <%= check_box_tag nil, nil, user.enabled?,
+        {
+          id: "toggle_status_#{dom_id(user)}",
+          data: {
+            'reflex': 'click->Application#toggle_status',
+            'reflex-dataset': 'combined',
+            'model': 'user',
+            'id': user.id
+          }
+        }
+      %>
+    <% end %>
+  </td>
+  <td><%= user.connections.size %></td>
+  <% if admin? %>
+    <td>
+      <%= content_tag :div, class: 'tags has-addons is-outline' do %>
+        <%= render partial: 'shared/button_delete', locals: { record: user } %>
+      <% end %>
+    </td>
+  <% end %>
+</tr>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -140,3 +140,12 @@ brocolli:
   groups:
     - veg
   role: member
+carrot:
+  email: carrot@veg.edu
+  encrypted_password: "<%= Devise::Encryptor.digest(User, 'password') %>"
+  enabled: false
+  group: veg
+  groups:
+    - veg
+    - xyz
+  role: member


### PR DESCRIPTION
When deleting a group if an associated user is affiliated with
another group then reassign the user to an available group. Only
delete the users that are exclusively associated with the group
being deleted.

This also adds an abbrev. assigned user table to a group page.