### PR TITLE
Manifest cleanup

### DIFF
--- a/app/jobs/reaper_unused_job.rb
+++ b/app/jobs/reaper_unused_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ReaperUnusedJob < ApplicationJob
+  queue_as :default
+  sidekiq_options retry: false
+
+  def perform
+    Manifest.unused(&:destroy)
+  end
+end

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -1,41 +1,21 @@
 # frozen_string_literal: true
 
 class Manifest < ApplicationRecord
-  URL_REGEXP = %r{^(http|https)://[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?$}ix.freeze
+  URL_REGEXP = %r{^(http|https)://[a-z0-9]+([\-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?$}ix.freeze
   has_many :mappers, dependent: :destroy
   validates :name, presence: true, uniqueness: true
   validates :url, presence: true, uniqueness: true,
                   format: { with: URL_REGEXP, multiline: true, message: 'Invalid' }
 
-  # gets rid of mappers no longer listed in mapper manifest(s)
-  # does not destroy mappers with batches still attached
-  # archive step should remove the batch/mapper connection?
   def clean_up
-    response = HTTP.get(url)
-    return false unless response.status.success?
-
-    current_mappers = []
-
-    begin
-      JSON.parse(response.body.to_s)['mappers'].each do |m|
-        current_mappers << m['url']
-      rescue StandardError => e
-        logger.error(e.message)
-      end
-    rescue JSON::ParserError => e
-      logger.error(e.message)
+    mappers.find_all { |m| m.batches_count.zero? }.each do |mapper|
+      mapper.destroy
+      yield self if block_given? # stream ui updates
     end
+  end
 
-    mappers.each do |m|
-      puts "Mapper url: #{m.url}, batches: #{m.batches_count}"
-      next unless m.batches_count.zero?
-      next if current_mappers.include?(m.url)
-
-      yield m if block_given?
-      logger.info "Deleting mapper for #{m.title} as it is no longer included in supported mapper config"
-      m.config.purge if m.config.attached?
-      m.destroy
-    end
+  def unused?
+    mappers.find_all { |m| m.batches_count.zero? }.count == mappers_count
   end
 
   def import
@@ -45,12 +25,18 @@ class Manifest < ApplicationRecord
     begin
       JSON.parse(response.body.to_s)['mappers'].each do |m|
         record = Mapper.create_or_update_from_json(self, m)
-        yield record if block_given?
+        yield record if block_given? # stream ui updates
       rescue StandardError => e
         logger.error(e.message)
       end
     rescue JSON::ParserError => e
       logger.error(e.message)
+    end
+  end
+
+  def self.unused(&block)
+    all.in_batches do |m|
+      m.find_all(&:unused?).each(&block)
     end
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,3 +5,6 @@
   reap_steps_in_limbo:
     class: ReaperLimboJob
     cron: '0 * * * *'
+  reap_unused_manifests:
+    class: ReaperUnusedJob
+    cron: '0 0 1 * *'

--- a/test/models/manifest_test.rb
+++ b/test/models/manifest_test.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ManifestTest < ActiveSupport::TestCase
-  # setup do
-  #   # TODO
-  # end
+  test 'can identify unused manifests' do
+    refute manifests(:dev).unused?
+    assert manifests(:example).unused?
 
-  # test '#' do
-  #   # TODO
-  # end
+    Manifest.unused { |m| assert_equal manifests(:example), m }
+  end
 end


### PR DESCRIPTION
Enable identification of unused manifests (all mappers have 0
batches). Clear out unused manifests on a monthly basis.