### PR TITLE
Adds enabled property to Manifest

### DIFF
--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -7,6 +7,10 @@ class Manifest < ApplicationRecord
   validates :url, presence: true, uniqueness: true,
                   format: { with: URL_REGEXP, multiline: true, message: 'Invalid' }
 
+  def active?
+    !unused?
+  end
+
   def clean_up
     mappers.find_all { |m| m.batches_count.zero? }.each do |mapper|
       mapper.destroy
@@ -15,7 +19,7 @@ class Manifest < ApplicationRecord
   end
 
   def unused?
-    mappers.find_all { |m| m.batches_count.zero? }.count == mappers_count
+    !enabled && mappers.find_all { |m| m.batches_count.zero? }.count == mappers_count
   end
 
   def import

--- a/app/views/manifests/_row.html.erb
+++ b/app/views/manifests/_row.html.erb
@@ -1,6 +1,30 @@
 <tr id="<%= dom_id(manifest) %>">
   <td><%= truncate manifest.name, length: 50 %></td>
   <td><%= link_to truncate(manifest.url, length: 75), manifest.url %></td>
+  <td>
+    <% if manifest.enabled? %>
+      <%= render partial: 'shared/icon',
+          locals: { classes: 'has-text-success', icon: 'thumbs-up' }
+      %>
+    <% else %>
+      <%= render partial: 'shared/icon',
+          locals: { classes: 'has-text-danger', icon: 'ban' }
+      %>
+    <% end %>
+    <% if can_toggle_status?(manifest) %>
+      <%= check_box_tag nil, nil, manifest.enabled?,
+        {
+          id: "toggle_status_#{dom_id(manifest)}",
+          data: {
+            'reflex': 'click->Application#toggle_status',
+            'reflex-dataset': 'combined',
+            'model': 'manifest',
+            'id': manifest.id
+          }
+        }
+      %>
+    <% end %>
+  </td>
   <td class="mappers_count"><%= manifest.mappers_count %></td>
   <td>
     <%= content_tag :div, class: 'tags has-addons is-outline' do %>

--- a/app/views/manifests/index.html.erb
+++ b/app/views/manifests/index.html.erb
@@ -11,6 +11,7 @@
     <tr>
       <th><%= t 'manifest.name' %></th>
       <th><%= t 'manifest.url' %></th>
+      <th><%= t 'manifest.enabled' %></th>
       <th><%= t 'manifest.mappers' %></th>
       <th colspan="1"></th>
       <th colspan="1"></th>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
     tooltip:
       email: This email address will be presented to new users of the group to request access.
   manifest:
+    enabled: Protected
     mappers: Mappers
     name: Name
     title:

--- a/db/migrate/20220625065955_add_protected_column_to_manifest.rb
+++ b/db/migrate/20220625065955_add_protected_column_to_manifest.rb
@@ -1,0 +1,5 @@
+class AddProtectedColumnToManifest < ActiveRecord::Migration[6.0]
+  def change
+    add_column :manifests, :enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_203401) do
+ActiveRecord::Schema.define(version: 2022_06_25_065955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_203401) do
   end
 
   create_table "manifests", force: :cascade do |t|
+    t.boolean "enabled", default: true
     t.string "name", null: false
     t.string "url", null: false
     t.integer "mappers_count", default: 0

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,12 +63,17 @@ if ENV.fetch('RAILS_ENV', 'development') == 'development'
     }
   ]
 
-  User.find_or_create_by!(email: 'admin@collectionspace.org') do |user|
+  admin = User.find_or_create_by!(email: 'admin@collectionspace.org') do |user|
     user.enabled = true
     user.password = Rails.configuration.superuser_password
     user.password_confirmation = Rails.configuration.superuser_password
     user.role = Role.admin
-    connections.each { |c| user.connections.build(c) }
+  end
+
+  begin
+    connections.each { |c| admin.connections.build(c) }
+  rescue StandardError
+    puts 'Unable to seed admin connections'
   end
 
   groups = [

--- a/test/fixtures/manifests.yml
+++ b/test/fixtures/manifests.yml
@@ -1,11 +1,19 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 dev:
+  enabled: true
   name: dev
   url: https://raw.githubusercontent.com/collectionspace/cspace-config-untangler/main/data/mapper_manifests/dev_mappers.json
   mappers_count: 6
 
 example:
+  enabled: false
   name: example
   url: http://example.com
   mappers_count: 1
+
+protected:
+  enabled: true
+  name: protected
+  url: http://example.com
+  mappers_count: 0

--- a/test/models/manifest_test.rb
+++ b/test/models/manifest_test.rb
@@ -3,10 +3,13 @@
 require 'test_helper'
 
 class ManifestTest < ActiveSupport::TestCase
-  test 'can identify unused manifests' do
-    refute manifests(:dev).unused?
-    assert manifests(:example).unused?
+  test 'can identify active manifests' do
+    assert manifests(:dev).active?
+    assert manifests(:protected).active?
+  end
 
+  test 'can identify unused manifests' do
+    assert manifests(:example).unused?
     Manifest.unused { |m| assert_equal manifests(:example), m }
   end
 end


### PR DESCRIPTION
Used in determining whether a manifest is active / unused. When
enabled a manifest is not eligible for auto-deletion via bg job.
For this reason enabled is represented as "Protected" in the UI.