### PR TITLE
Missing term handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.14.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v4.0.3', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v4.0.4', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 
 gem 'csvlint'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: 1fd73b72d092eff4f1beb77e52df479de816aeea
-  tag: v4.0.3
+  revision: 43dd3268c90b547f663576b473aabb8804f64eca
+  tag: v4.0.4
   specs:
-    collectionspace-mapper (4.0.3)
+    collectionspace-mapper (4.0.4)
       activesupport (= 6.0.4.7)
       chronic
       dry-configurable (~> 0.14)


### PR DESCRIPTION
- removes reporting of missing term identifiers (as they do not have any) - I think/hope this is what was causing failures recently reported for OHC, WESTAF, and UCJEPS, although I was not able to reproduce the prod error exactly in local dev environment/testing
- use v4.0.4 of `collectionspace-mapper` which no longer outputs duplicate missing term errors when a client search does not find a term