### PR TITLE
Log full process error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.14.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v4.0.4', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v4.0.6', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 
 gem 'csvlint'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: 43dd3268c90b547f663576b473aabb8804f64eca
-  tag: v4.0.4
+  revision: aea6f318a9b7838dcb04a162b04f626cb2dea9b4
+  tag: v4.0.6
   specs:
-    collectionspace-mapper (4.0.4)
+    collectionspace-mapper (4.0.6)
       activesupport (= 6.0.4.7)
       chronic
       dry-configurable (~> 0.14)

--- a/app/jobs/process_job.rb
+++ b/app/jobs/process_job.rb
@@ -36,6 +36,9 @@ class ProcessJob < ApplicationJob
         begin
           results = [handler.process(data)].flatten
         rescue StandardError => e
+          Rails.logger.error(e.message)
+          Rails.logger.error(e.backtrace)
+
           manager.add_warning!
           rep.append({ row: row_num,
                       header: 'ERR: mapper',


### PR DESCRIPTION
- bump collectionspace-mapper version to get failed-to-parse URN value in error message
- log full `handler.process` error backtrace