### PR TITLE
Use collectionspace-mapper 4.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.14.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v4.0.7', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v4.1.1', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 
 gem 'csvlint'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,13 +10,14 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: 0e8d150ea0939fdd555f4efabc99532359961f0d
-  tag: v4.0.7
+  revision: f97f288c7bdaa8b7252b94bda473a3b550553497
+  tag: v4.1.1
   specs:
-    collectionspace-mapper (4.0.7)
+    collectionspace-mapper (4.1.1)
       activesupport (= 6.0.4.7)
       chronic
       dry-configurable (~> 0.14)
+      dry-monads (~> 1.4)
       memo_wise (~> 1.1.0)
       nokogiri (~> 1.13.3)
       xxhash (>= 0.4.0)
@@ -190,6 +191,9 @@ GEM
       dry-core (~> 0.6)
     dry-core (0.8.1)
       concurrent-ruby (~> 1.0)
+    dry-monads (1.4.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.7)
     e2mmap (0.1.0)
     erubi (1.10.0)
     escape_utils (1.2.1)


### PR DESCRIPTION
This fixes a bug where year-only dates with less than four digits produce CSXML that does not validate in the ingest process. 