### PR TITLE
Display csvlint errors

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -58,6 +58,9 @@ class BatchesController < ApplicationController
       if validator.valid? && within_csv_row_limit?(validator.row_count)
         @batch.update(num_rows: validator.row_count)
         continue = true
+      elsif !within_csv_row_limit?(validator.row_count)
+        @batch.destroy # scrap it, they'll have to start over
+        flash[:csv_too_long] = true
       else
         @batch.destroy # scrap it, they'll have to start over
         flash[:csv_lint] = true

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -32,22 +32,6 @@
   </article>
 <% end %>
 
-<% if flash[:batch_config] %>
-  <article class="flash message is-danger is-small mt-3">
-    <div class="message-header">
-      <p>Issues were found with JSON batch config</p>
-    </div>
-    <div class="message-body">
-      <ul>
-        <% flash[:batch_config].each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-      <p class="content">Please <a href="https://jsonlint.com">validate your JSON batch config externally</a> and re-create your batch above.</p>
-    </div>
-  </article>
-<% end %>
-
   <div class="columns">
     <div class="column">
       <div class="columns is-multiline">

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -104,6 +104,17 @@
   </article>
 <% end %>
 
+<% if flash[:csv_too_long] %>
+  <article class="flash message is-danger is-small mt-3">
+    <div class="message-header">
+      <p>Uploaded CSV has more than <%= csv_row_limit %> rows</p>
+    </div>
+    <div class="message-body">
+      <p class="content">The maximum number of rows this tool can import from a single CSV is <%= csv_row_limit %>. Please break your CSV file into multiple smaller files and create a separate batch for each.</p>
+    </div>
+  </article>
+<% end %>
+
 <% if flash[:batch_config] %>
   <article class="flash message is-danger is-small mt-3">
     <div class="message-header">

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -96,10 +96,21 @@
 <% if flash[:csv_lint] %>
   <article class="flash message is-danger is-small mt-3">
     <div class="message-header">
-      <p>Uploaded CSV is invalid or too large (>= <%= csv_row_limit %> rows)</p>
+      <p>Uploaded CSV is invalid</p>
     </div>
     <div class="message-body">
-      <p class="content">Please upload and validate your file at <a>https://csvlint.io/</a>, fix any issues that tool finds, and then try again.</p>
+      <p class="content">
+	Consult <a href="https://github.com/Data-Liberation-Front/csvlint.rb/#errors">csvlint's errors documentation</a> for more info on what the different errors mean.</p>
+	<ul>
+	<% flash[:csv_lint].split('|||').each do |err| %>
+	  <li><%= err %></li>
+	<% end %>
+	</ul>
+      <p>&nbsp;</p>
+      <p>If you are getting "unknown_error", some things to check for might include:</p>
+      <ul>
+	<li>Line breaks within a CSV cell may be breaking the CSV structure</li>
+      </ul>
     </div>
   </article>
 <% end %>

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -1,4 +1,53 @@
 <%= form_with(model: batch, local: true, id: dom_id(batch), class: 'mt-3', data: { 'reflex-root': '#mappers' }) do |form| %>
+<% if flash[:csv_lint] %>
+  <article class="flash message is-danger is-small mt-3">
+    <div class="message-header">
+      <p>Uploaded CSV is invalid</p>
+    </div>
+    <div class="message-body">
+      <p class="content">
+	Consult <a href="https://github.com/Data-Liberation-Front/csvlint.rb/#errors">csvlint's errors documentation</a> for more info on what the different errors mean.</p>
+	<ul>
+	<% flash[:csv_lint].split('|||').each do |err| %>
+	  <li><%= err %></li>
+	<% end %>
+	</ul>
+      <p>&nbsp;</p>
+      <p>If you are getting "unknown_error", some things to check for might include:</p>
+      <ul>
+	<li>Line breaks within a CSV cell may be breaking the CSV structure</li>
+      </ul>
+    </div>
+  </article>
+<% end %>
+
+<% if flash[:csv_too_long] %>
+  <article class="flash message is-danger is-small mt-3">
+    <div class="message-header">
+      <p>Uploaded CSV has more than <%= csv_row_limit %> rows</p>
+    </div>
+    <div class="message-body">
+      <p class="content">The maximum number of rows this tool can import from a single CSV is <%= csv_row_limit %>. Please break your CSV file into multiple smaller files and create a separate batch for each.</p>
+    </div>
+  </article>
+<% end %>
+
+<% if flash[:batch_config] %>
+  <article class="flash message is-danger is-small mt-3">
+    <div class="message-header">
+      <p>Issues were found with JSON batch config</p>
+    </div>
+    <div class="message-body">
+      <ul>
+        <% flash[:batch_config].each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+      <p class="content">Please <a href="https://jsonlint.com">validate your JSON batch config externally</a> and re-create your batch above.</p>
+    </div>
+  </article>
+<% end %>
+
   <div class="columns">
     <div class="column">
       <div class="columns is-multiline">
@@ -91,53 +140,4 @@
       <%= render partial: 'field_definitions' %>
     </div>
   </div>
-<% end %>
-
-<% if flash[:csv_lint] %>
-  <article class="flash message is-danger is-small mt-3">
-    <div class="message-header">
-      <p>Uploaded CSV is invalid</p>
-    </div>
-    <div class="message-body">
-      <p class="content">
-	Consult <a href="https://github.com/Data-Liberation-Front/csvlint.rb/#errors">csvlint's errors documentation</a> for more info on what the different errors mean.</p>
-	<ul>
-	<% flash[:csv_lint].split('|||').each do |err| %>
-	  <li><%= err %></li>
-	<% end %>
-	</ul>
-      <p>&nbsp;</p>
-      <p>If you are getting "unknown_error", some things to check for might include:</p>
-      <ul>
-	<li>Line breaks within a CSV cell may be breaking the CSV structure</li>
-      </ul>
-    </div>
-  </article>
-<% end %>
-
-<% if flash[:csv_too_long] %>
-  <article class="flash message is-danger is-small mt-3">
-    <div class="message-header">
-      <p>Uploaded CSV has more than <%= csv_row_limit %> rows</p>
-    </div>
-    <div class="message-body">
-      <p class="content">The maximum number of rows this tool can import from a single CSV is <%= csv_row_limit %>. Please break your CSV file into multiple smaller files and create a separate batch for each.</p>
-    </div>
-  </article>
-<% end %>
-
-<% if flash[:batch_config] %>
-  <article class="flash message is-danger is-small mt-3">
-    <div class="message-header">
-      <p>Issues were found with JSON batch config</p>
-    </div>
-    <div class="message-body">
-      <ul>
-        <% flash[:batch_config].each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-      <p class="content">Please <a href="https://jsonlint.com">validate your JSON batch config externally</a> and re-create your batch above.</p>
-    </div>
-  </article>
 <% end %>


### PR DESCRIPTION
It looks like the error behavior has changed to **not** pop up in a temporary, small widget thingie. It now displays at the bottom of the form page, and seems to stay there until you move off the page. 

Because of this, it was way more straightforward to just show the validation errors in this same interface. 

Since a too-long CSV and an invalid CSV are two separate issues, I separated the flash that gets triggered for each. 

I moved the error message to the top of the result/redirected form, since it is the most important thing to know. (Before making any changes I created 3 invalid batches wondering why I was getting NO error messages at all, before realizing they were just at the bottom of the screen and I needed to scroll down to see them.)

I tested this locally, but could not figure out how to get any `assert_select 'p.flash'` tests to pass in the tests for malformed and too long CSVs in batches_controller_test.rb