### PR TITLE
Use collectionspace-mapper 4.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.14.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
-gem 'collectionspace-mapper', tag: 'v4.1.1', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v4.1.2', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 
 gem 'csvlint'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: f97f288c7bdaa8b7252b94bda473a3b550553497
-  tag: v4.1.1
+  revision: f85cac33c27392499a9574f262f7515bfd2c31e8
+  tag: v4.1.2
   specs:
-    collectionspace-mapper (4.1.1)
+    collectionspace-mapper (4.1.2)
       activesupport (= 6.0.4.7)
       chronic
       dry-configurable (~> 0.14)


### PR DESCRIPTION
collectionspace-mapper 4.1.2 fixes a bug that could make the Processing step fail if an unparseable-to-structured-date 2-digit year date string was encountered.