### PR TITLE
Remove dependency on collectionspace-mapper DataHandler to get service_type

### DIFF
--- a/app/jobs/process_job.rb
+++ b/app/jobs/process_job.rb
@@ -17,6 +17,8 @@ class ProcessJob < ApplicationJob
 
     begin
       handler = process.batch.handler
+      service_type = process.batch
+        .record_mapper['config']['service_type']
       rcs = RecordCacheService.new(batch_id: process.batch.id)
 
       rep = ReportService.new(name: "#{manager.filename_base}_processed",
@@ -77,7 +79,7 @@ class ProcessJob < ApplicationJob
           else
             rus.add(row: row_num, row_occ: row_occ, rec_id: id)
 
-            if handler.service_type == 'relation'
+            if service_type == 'relation'
               rep.append({ row: row_num,
                           row_occ: row_occ,
                           header: 'INFO: relationship id',

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -58,10 +58,13 @@ class Batch < ApplicationRecord
     Digest::SHA2.hexdigest "#{id}-#{name}"
   end
 
+  def record_mapper
+    @record_mapper ||= fetch_mapper
+  end
+
   def handler
-    @rm ||= fetch_mapper
     CollectionSpace::Mapper::DataHandler.new(
-      record_mapper: @rm,
+      record_mapper: record_mapper,
       client: connection.client,
       cache: connection.refcache,
       csid_cache: connection.csidcache,

--- a/app/services/record_transfer_service.rb
+++ b/app/services/record_transfer_service.rb
@@ -22,8 +22,8 @@ class RecordTransferService
     @transfer_step = transfer
     @batch = transfer.batch
     @client = @batch.connection.client
-    mapper = get_mapper
-    @service_type = transfer.batch.handler.service_type
+    mapper = @batch.record_mapper
+    @service_type = mapper['config']['service_type']
     @type = mapper['config']['service_path']
     @subtype = mapper['config']['authority_subtype']
     @blob_checker = BlobCheckService.new(client: @client)
@@ -156,11 +156,5 @@ class RecordTransferService
     return :irrelevant if data['bloburi'].blank?
 
     @blob_checker.status(uri: data['uri'])
-  end
-
-  def get_mapper
-    Rails.cache.fetch(@batch.mapper.title, namespace: 'mapper', expires_in: 1.day) do
-      JSON.parse(@batch.mapper.config.download)
-    end
   end
 end


### PR DESCRIPTION
service_type is derived from the record mapper, which exists before and separate from the DataHandler.