### PR TITLE
Use collectionspace-client 0.15.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'
 gem 'aws-sdk-s3', require: false
 gem 'bulma-rails', '~> 0.9.0'
 
-gem 'collectionspace-client', tag: 'v0.14.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
+gem 'collectionspace-client', tag: 'v0.15.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
 gem 'collectionspace-mapper', tag: 'v4.1.2', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/collectionspace/collectionspace-client.git
-  revision: b1240d71ca95085ece7b3d1f2f067b538ab9eb2f
-  tag: v0.14.1
+  revision: e9d6a307374a29ac9e1d2449516764bdcef2838b
+  tag: v0.15.1
   specs:
-    collectionspace-client (0.14.1)
+    collectionspace-client (0.15.1)
       httparty
       json
       nokogiri
@@ -226,8 +226,8 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httparty (0.20.0)
-      mime-types (~> 3.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
Adds support for importing new Chronology authority record types

Minitest suite passed on my local dev environment and I was able to [load chronology event terms to core](https://core.collectionspace.org/cspace/core/list/chronology/event?size=20&p=1) and [chronology field collection terms to anthro](https://anthro.collectionspace.org/cspace/anthro/list/chronology/fieldcollection?size=20&p=1)