### PR TITLE
gh-194: Prevent creation of batch with now-invalid connection

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -96,10 +96,9 @@ class Batch < ApplicationRecord
 
     batch.spreadsheet.open do |spreadsheet|
       config = { header: true, delimiter: ',' }
-      validator = Csvlint::Validator.new(
+      Csvlint::Validator.new(
         File.new(spreadsheet.path), config, nil
       )
-      yield validator
     end
   end
 

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -32,6 +32,17 @@
   </article>
 <% end %>
 
+<% if flash[:invalid_connection] %>
+  <article class="flash message is-danger is-small mt-3">
+    <div class="message-header">
+      <p>Problem connecting to CollectionSpace</p>
+    </div>
+    <div class="message-body">
+      <p class="content"><%= flash[:invalid_connection] %></p>
+    </div>
+  </article>
+<% end %>
+
   <div class="columns">
     <div class="column">
       <div class="columns is-multiline">


### PR DESCRIPTION
Closes #194 

As users have been using the CSV Importer for longer periods of time, we are increasingly running into a situation where a connection that was valid when initially created has become functionally invalid because a password has been changed in CollectionSpace application. 

Currently, since no CRUD operation is done on a connection when a batch is created, you can create a batch with a connection that is no longer able to connect to a CollectionSpace instance. This results in the user reaching/running the processing step, only to have every single record fail with the following message because the connection that has been passed to collectionspace-mapper doesn't return any results when it tries to look up the record status: 

```
Mapper did not return result for unexpected reason. Please send a copy of this report to [collectionspace@lyrasis.org](mailto:collectionspace@lyrasis.org). We will use the following info to diagnose and fix the problem, but you may ignore it: undefined method `dig' for nil:NilClass -- /usr/local/bundle/bundler/gems/collectionspace-mapper-f85cac33c273/lib/collectionspace/mapper/searcher.rb:59:in `response_item_count'
```

This error doesn't AT ALL indicate what the actual issue is. 

Also, it's a waste of user time to pre-process a batch that can't be processed or transferred. 

The actual issue is very easy for a user to fix without asking us for help, but I keep having to deal with tickets about this problem. 

This PR causes new batch creation to fail if the selected connection no longer validates. When it fails, it displays a clear error indicating the user should update the URL and or login credentials in the connection they attempted to use. 

NOTE 1: I did not write a new test for this behavior because I could not figure out how to create a fake test connection with bad credentials (since CREATION of a new connection won't let you)

NOTE 2: What I've done here (called `@batch.controller.validate` from the `batches_controller`) might be a forbidden, horrendous Rails transgression. I do realize this means we end up with DB-stored connections that are flagged as invalid. However, they ARE invalid since they can no longer be used to connect to an instance. 

I tried a few other things first, but none worked, due to the core Rails thing of "only validate a Model object on a CRUD operation on that object".

This worked and fixes an increasingly annoying issue I keep having to solve in Zendesk, etc.