### PR TITLE
Cache mapper on digest not title

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -128,7 +128,7 @@ class Batch < ApplicationRecord
   end
 
   def fetch_mapper
-    Rails.cache.fetch(mapper.title, namespace: 'mapper', expires_in: 1.day) do
+    Rails.cache.fetch(mapper.digest, namespace: 'mapper', expires_in: 1.day) do
       JSON.parse(mapper.config.download)
     end
   end


### PR DESCRIPTION
There have been cases where the mapper content has changed but caching on title means the incorrect mapper is being used until the cache expires. Caching on digest should be fine in all cases.