### PR TITLE
Better error descriptions if CSV is invalid

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -99,7 +99,7 @@ class Batch < ApplicationRecord
     CONTENT_TYPES
   end
 
-  def self.csv_validator_for(batch)
+  def self.csv_lint_validator_for(batch)
     # raise unless batch.spreadsheet.attached? # TODO
 
     batch.spreadsheet.open do |spreadsheet|
@@ -111,10 +111,26 @@ class Batch < ApplicationRecord
     end
   end
 
+  def self.csv_parse_validator_for(batch)
+    # raise unless batch.spreadsheet.attached? # TODO
+
+    batch.spreadsheet.open do |spreadsheet|
+      yield batch.parse_spreadsheet(spreadsheet.path)
+    end
+  end
+
   def self.expired(&block)
     all.in_batches do |b|
       b.find_all(&:expired?).each(&block)
     end
+  end
+
+  def parse_spreadsheet(path)
+    File.open(path, encoding: 'bom|utf-8') { |file| CSV.table(file) }
+  rescue CSV::MalformedCSVError => e
+    e.message
+  else
+    :success
   end
 
   private

--- a/app/services/invalid_character_finder.rb
+++ b/app/services/invalid_character_finder.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# This service returns non-UTF-8 characters from an uploaded CSV, with their
+#   surrounding context, so that users can find the characters that need to
+#   be replaced
+class InvalidCharacterFinder
+  def initialize(csv_string)
+    @csv_string = csv_string
+    @char_ct = csv_string.length
+    @context_chars = 20
+    @min_idx = context_chars - 1
+    @max_idx = char_ct - context_chars - 1
+    @replacement_char = '�'
+  end
+
+  # @return [Array<String>]
+  def call
+    invalid_char_indexes.values
+                        .map do |idx|
+      [context(idx, :before),
+       replacement_char,
+       context(idx, :after)].join
+    end
+  end
+
+  private
+
+  attr_reader :csv_string, :char_ct, :context_chars, :min_idx, :max_idx,
+              :replacement_char
+
+  # @return [Hash<String=>Integer>] unique invalid characters in CSV as keys;
+  #   index of first occurrence of the string as values
+  def invalid_char_indexes
+    csv_string.chars
+              .map.with_index { |char, idx| char.is_utf8? ? nil : [char, idx] }
+              .compact
+              .group_by { |arr| arr[0] }
+              .values
+              .map { |arr| arr.first }
+              .to_h
+  end
+
+  # @return [String] with any invalid UTF-8 characters occurring in the context
+  #   replaced by replacement_char
+  def context(idx, mode)
+    range = if mode == :before
+              Range.new(min(idx), idx - 1)
+            else
+              Range.new(idx + 1, max(idx))
+            end
+    csv_string.slice(range)
+              .chars
+              .map { |char| char.is_utf8? ? char : replacement_char }
+  end
+
+  def min(idx)
+    idx < min_idx ? 0 : idx - context_chars
+  end
+
+  def max(idx)
+    idx > max_idx ? char_ct - 1 : idx + context_chars
+  end
+end

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -1,172 +1,240 @@
 <%= form_with(model: batch, local: true, id: dom_id(batch), class: 'mt-3', data: { 'reflex-root': '#mappers' }) do |form| %>
 <% if flash[:csv_lint] %>
-  <article class="flash message is-danger is-small mt-3">
-    <div class="message-header">
-      <p>Uploaded CSV is invalid</p>
-    </div>
-    <div class="message-body">
-      <p class="content">
-	Consult <a href="https://github.com/Data-Liberation-Front/csvlint.rb/#errors">csvlint's errors documentation</a> for more info on what the different errors mean.</p>
-	<ul>
-	<% flash[:csv_lint].split('|||').each do |err| %>
-	  <li><%= err %></li>
-	<% end %>
-	</ul>
-      <p>&nbsp;</p>
-      <p>If you are getting "unknown_error", some things to check for might include:</p>
-      <ul>
-	<li>Line breaks within a CSV cell may be breaking the CSV structure</li>
-      </ul>
-    </div>
-  </article>
+<article class="flash message is-danger is-small mt-3">
+  <div class="message-header">
+    <p>Uploaded CSV is invalid</p>
+  </div>
+  <div class="message-body">
+    <p class="content">
+      Consult <a href="https://github.com/Data-Liberation-Front/csvlint.rb/#errors">csvlint's errors documentation</a> for more info on what the different errors mean.</p>
+    <ul>
+      <% flash[:csv_lint].split('|||').each do |err| %>
+      <li><%= err %></li>
+      <% end %>
+    </ul>
+    <p>&nbsp;</p>
+    <p>If you are getting "unknown_error", some things to check for might include:</p>
+    <ul>
+      <li>Line breaks within a CSV cell may be breaking the CSV structure</li>
+      <li>Remove any blank lines in the CSV, including at the end of the file.
+    </ul>
+    <p>&nbsp;</p>
+    <p>The <a href="https://collectionspace.atlassian.net/wiki/spaces/COL/pages/3093004295/User+Manual+CSV+Importer+Dealing+with+invalid+CSVs#Finding-and-removing-blank-lines%2Frows">
+	CSV Importer User Manual</a> contains some tips and tricks for dealing
+      with blank rows.</p>
+  </div>
+</article>
 <% end %>
 
-<% if flash[:csv_lint_invalid_encoding] %>
-  <article class="flash message is-danger is-small mt-3">
-    <div class="message-header">
-      <p>Uploaded CSV contains characters with invalid encoding</p>
-    </div>
-    <div class="message-body">
-      <p class="content">
-	Your CSV must contain only valid UTF-8 characters. It currently contains
-	characters with invalid encoding.
-      </p>
-      <p class="content">
-	Below, one entry is shown for the first occurrence of each unique
-	invalid character in your CSV. The invalid characters here have been
-	replaced with �, but may look different in your file on your machine.
-      </p>
-      <p class="content">
-        Each entry below displays the text immediately before and after the
-	invalid character, so you can more easily identify each invalid
-	character in your file. This contextual text may contain other invalid
-	characters, also replaced with �. The invalid character whose first
-	occurrence is captured in the entry will be the middle character of the
-	entry, unless the it occurs very close to the beginning or end of your
-	file.
-      </p>
-      <p class="content">
-	Once you identify the invalid character represented in each entry below,
-	find/replace all instances of the invalid character in your file.
-      </p>
-      <p class="content">
-	Note that the context shown may stretch across columns, may show the ","
-	column delimiter, or may show line breaks. Opening your CSV as a text
-	file in Notepad or other text editor will show you something closer to
-	what is in the entries below. Just remember that the valid UTF-8 �
-	character in the entries below is always a substitute for some other
-	invalid character in your CSV.
-      </p>
-	<ul>
-	<% flash[:csv_lint_invalid_encoding].split('|||').each do |err| %>
-	  <li>🔴 <%= err %></li>
-	<% end %>
-	</ul>
-    </div>
-  </article>
+<% if flash[:invalid_encoding] %>
+<article class="flash message is-danger is-small mt-3">
+  <div class="message-header">
+    <p>Uploaded CSV contains characters with invalid encoding</p>
+  </div>
+  <div class="message-body">
+    <p class="content">
+      Your CSV must contain only valid UTF-8 characters. It currently contains
+      characters with invalid encoding.
+    </p>
+    <p class="content">
+      Below, one entry is shown for the first occurrence of each unique
+      invalid character in your CSV. The invalid characters here have been
+      replaced with �, but may look different in your file on your machine.
+    </p>
+    <p class="content">
+      Each entry below displays the text immediately before and after the
+      invalid character, so you can more easily identify each invalid
+      character in your file. This contextual text may contain other invalid
+      characters, also replaced with �. The invalid character whose first
+      occurrence is captured in the entry will be the middle character of the
+      entry, unless the it occurs very close to the beginning or end of your
+      file.
+    </p>
+    <p class="content">
+      Once you identify the invalid character represented in each entry below,
+      find/replace all instances of the invalid character in your file.
+    </p>
+    <p class="content">
+      Note that the context shown may stretch across columns, may show the ","
+      column delimiter, or may show line breaks. Opening your CSV as a text
+      file in Notepad or other text editor will show you something closer to
+      what is in the entries below. Just remember that the valid UTF-8 �
+      character in the entries below is always a substitute for some other
+      invalid character in your CSV.
+    </p>
+    <ul>
+      <% flash[:invalid_encoding].split('|||').each do |err| %>
+      <li><%= err %><br/>&nbsp;</li>
+      <% end %>
+    </ul>
+  </div>
+</article>
 <% end %>
 
 <% if flash[:csv_too_long] %>
-  <article class="flash message is-danger is-small mt-3">
-    <div class="message-header">
-      <p>Uploaded CSV has more than <%= csv_row_limit %> rows</p>
-    </div>
-    <div class="message-body">
-      <p class="content">The maximum number of rows this tool can import from a single CSV is <%= csv_row_limit %>. Please break your CSV file into multiple smaller files and create a separate batch for each.</p>
-    </div>
-  </article>
+<article class="flash message is-danger is-small mt-3">
+  <div class="message-header">
+    <p>Uploaded CSV has more than <%= csv_row_limit %> rows</p>
+  </div>
+  <div class="message-body">
+    <p class="content">The maximum number of rows this tool can import from a single CSV is <%= csv_row_limit %>. Please break your CSV file into multiple smaller files and create a separate batch for each.</p>
+  </div>
+</article>
 <% end %>
 
-  <div class="columns">
-    <div class="column">
-      <div class="columns is-multiline">
-        <%= content_tag :div, class: 'column is-half' do %>
-          <%= content_tag :div, class: 'field' do %>
-            <%= form.label t('batch.name'), class: 'label' %>
-            <%= content_tag :div, class: 'control has-icons-left' do %>
-              <%= form.text_field :name, class: 'input', placeholder: t('batch.name'),
-                autofocus: (batch.name.blank? ? true : false)
-              %>
-              <%= render partial: 'shared/icon',
-                  locals: { classes: 'has-text-danger is-small is-left', icon: 'asterisk' }
-              %>
-            <% end %>
-          <% end %>
-        <% end %>
+<% if flash[:blank_rows] %>
+<article class="flash message is-danger is-small mt-3">
+  <div class="message-header">
+    <p>CSV contains invalid blank rows</p>
+  </div>
+  <div class="message-body">
+    <p class="content">
+      Please delete any blank/empty rows from your CSV file. This includes empty
+      rows in between actual data rows, as well as extra empty rows at the end
+      of your file.
+    </p>
+    <p class="content">
+      The <a href="https://collectionspace.atlassian.net/wiki/spaces/COL/pages/3093004295/User+Manual+CSV+Importer+Dealing+with+invalid+CSVs#Finding-and-removing-blank-lines%2Frows">
+	CSV Importer User Manual</a> contains some tips and tricks for dealing
+      with blank rows.
+    </p>
+  </div>
+</article>
+<% end %>
 
-        <%= content_tag :div, class: 'column is-half' do %>
-          <%= content_tag :div, class: 'field' do %>
-            <%= form.label t('batch.group'), class: 'label' %>
-            <div class="select is-fullwidth">
-              <%= form.collection_select :group_id, Group.select_options_with_default(current_user), :id, :name,
-                  { selected: current_user.group_id }, disabled: !admin? %>
-            </div>
-          <% end %>
-        <% end %>
+<% if flash[:last_row_eol] %>
+<article class="flash message is-danger is-small mt-3">
+  <div class="message-header">
+    <p>CSV has invalid end-of-line character on last row</p>
+  </div>
+  <div class="message-body">
+    <p class="content">
+      The last row of your CSV ends with a line break that does not
+      match the line breaks used in the rest of the CSV file.
+      The easiest way to fix this is:
+    </p>
+      <ul>
+	<li>Open your CSV using a plain-text editor like Notepad or Notepad++</li>
+	<li>Go to the very end of the file</li>
+	<li>If your cursor can be put at the beginning of a blank line at the
+	  bottom of the file, backspace until the farthest your cursor can go is
+	  the end of the last line of data</li>
+      </ul>
+    <p class="content">
+      If you use Notepad++, the Edit &gt; EOL Conversion feature should also fix
+      this issue.
+    </p>
+  </div>
+</article>
+<% end %>
 
-        <%= content_tag :div, class: 'column is-half' do %>
-          <%= form.label t('batch.connection'), class: 'label' %>
-          <div class="select is-fullwidth">
-            <%= form.collection_select :connection_id, connections_for_batch,
-              :id, :name, { selected: @connection.id }, data: { 'reflex': 'change->Connection#selected' }
-            %>
-          </div>
-        <% end %>
+<% if flash[:malformed_csv] %>
+<article class="flash message is-danger is-small mt-3">
+  <div class="message-header">
+    <p>Malformed CSV</p>
+  </div>
+  <div class="message-body">
+    <p class="content">
+      This CSV has structural issues that cause the following error
+      when the CSV Importer attempts to parse it: <%= flash[:malformed_csv] %>.
+      The <a href="https://collectionspace.atlassian.net/wiki/spaces/COL/pages/3093004295/User+Manual+CSV+Importer+Dealing+with+invalid+CSVs">
+	CSV Importer User Manual</a> has some tips and tricks for dealing with
+      invalid CSVs which may help.
+    </p>
+  </div>
+</article>
+<% end %>
 
-        <%= content_tag :div, id: 'mappers', class: 'column is-half' do %>
-          <div class="field">
-            <%= form.label t('batch.mapper'), class: 'label' %>
-            <div class="select is-fullwidth">
-              <%= form.collection_select :mapper_id, Mapper.select_options(@connection), :id, :title,
-                  selected: Mapper.select_options(@connection).first
-              %>
-            </div>
-          </div>
-        <% end %>
+<div class="columns">
+  <div class="column">
+    <div class="columns is-multiline">
+      <%= content_tag :div, class: 'column is-half' do %>
+      <%= content_tag :div, class: 'field' do %>
+      <%= form.label t('batch.name'), class: 'label' %>
+      <%= content_tag :div, class: 'control has-icons-left' do %>
+      <%= form.text_field :name, class: 'input', placeholder: t('batch.name'),
+          autofocus: (batch.name.blank? ? true : false)
+          %>
+      <%= render partial: 'shared/icon',
+          locals: { classes: 'has-text-danger is-small is-left', icon: 'asterisk' }
+          %>
+      <% end %>
+      <% end %>
+      <% end %>
 
-        <%= content_tag :div, class: 'column is-three-quarters' do %>
-          <%= form.label t('batch.file'), class: 'label' %>
-          <%= content_tag :div, class: 'file mb-3 is-fullwidth' do %>
-            <%= content_tag :label, class: 'file-label' do %>
-              <%=
-                form.file_field :spreadsheet, accept: csv_content_types, required: true,
-                class: 'file-input', onchange: filename_js
-              %>
-              <%= content_tag :span, class: 'file-cta' do %>
-                <%= fa_icon('upload') %>
-                <%= content_tag :span, class: 'file-label ml-2' do %>
-                  Select file
-                <% end %>
-              <% end %>
-              <%= content_tag :span, id: 'file-name', class: 'file-name' do %>
-                No file selected
-              <% end %>
-            <% end %>
-          <% end %>
-        <% end %>
-
-        <%= content_tag :div, class: 'column is-one-quarter' do %>
-        <% end %>
-
-        <%= content_tag :div, class: 'column is-full' do %>
-          <%= content_tag :div, class: 'field' do %>
-            <%= form.label t('batch.config.label'), class: 'label' %>
-            <%= form.text_area :batch_config, id: 'batch_config_entry' %>
-          <% end %>
-        <% end %>
-
-        <%= content_tag :div, class: 'column is-full' do %>
-          <div class="field is-grouped">
-            <div class="control">
-              <%= form.button t('action.submit'), class: 'button is-link',
-                  data: { 'disable-with': spinner_html }, style: 'min-width: 5rem;' %>
-            </div>
-          </div>
-        <% end %>
+      <%= content_tag :div, class: 'column is-half' do %>
+      <%= content_tag :div, class: 'field' do %>
+      <%= form.label t('batch.group'), class: 'label' %>
+      <div class="select is-fullwidth">
+        <%= form.collection_select :group_id, Group.select_options_with_default(current_user), :id, :name,
+            { selected: current_user.group_id }, disabled: !admin? %>
       </div>
-    </div>
-    <div class="column">
-      <%= render partial: 'field_definitions' %>
+      <% end %>
+      <% end %>
+
+      <%= content_tag :div, class: 'column is-half' do %>
+      <%= form.label t('batch.connection'), class: 'label' %>
+      <div class="select is-fullwidth">
+        <%= form.collection_select :connection_id, connections_for_batch,
+            :id, :name, { selected: @connection.id }, data: { 'reflex': 'change->Connection#selected' }
+            %>
+      </div>
+      <% end %>
+
+      <%= content_tag :div, id: 'mappers', class: 'column is-half' do %>
+      <div class="field">
+        <%= form.label t('batch.mapper'), class: 'label' %>
+        <div class="select is-fullwidth">
+          <%= form.collection_select :mapper_id, Mapper.select_options(@connection), :id, :title,
+              selected: Mapper.select_options(@connection).first
+              %>
+        </div>
+      </div>
+      <% end %>
+
+      <%= content_tag :div, class: 'column is-three-quarters' do %>
+      <%= form.label t('batch.file'), class: 'label' %>
+      <%= content_tag :div, class: 'file mb-3 is-fullwidth' do %>
+      <%= content_tag :label, class: 'file-label' do %>
+      <%=
+        form.file_field :spreadsheet, accept: csv_content_types, required: true,
+        class: 'file-input', onchange: filename_js
+        %>
+      <%= content_tag :span, class: 'file-cta' do %>
+      <%= fa_icon('upload') %>
+      <%= content_tag :span, class: 'file-label ml-2' do %>
+      Select file
+      <% end %>
+      <% end %>
+      <%= content_tag :span, id: 'file-name', class: 'file-name' do %>
+      No file selected
+      <% end %>
+      <% end %>
+      <% end %>
+      <% end %>
+
+      <%= content_tag :div, class: 'column is-one-quarter' do %>
+      <% end %>
+
+      <%= content_tag :div, class: 'column is-full' do %>
+      <%= content_tag :div, class: 'field' do %>
+      <%= form.label t('batch.config.label'), class: 'label' %>
+      <%= form.text_area :batch_config, id: 'batch_config_entry' %>
+      <% end %>
+      <% end %>
+
+      <%= content_tag :div, class: 'column is-full' do %>
+      <div class="field is-grouped">
+        <div class="control">
+          <%= form.button t('action.submit'), class: 'button is-link',
+              data: { 'disable-with': spinner_html }, style: 'min-width: 5rem;' %>
+        </div>
+      </div>
+      <% end %>
     </div>
   </div>
+  <div class="column">
+    <%= render partial: 'field_definitions' %>
+  </div>
+</div>
 <% end %>

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -21,6 +21,51 @@
   </article>
 <% end %>
 
+<% if flash[:csv_lint_invalid_encoding] %>
+  <article class="flash message is-danger is-small mt-3">
+    <div class="message-header">
+      <p>Uploaded CSV contains characters with invalid encoding</p>
+    </div>
+    <div class="message-body">
+      <p class="content">
+	Your CSV must contain only valid UTF-8 characters. It currently contains
+	characters with invalid encoding.
+      </p>
+      <p class="content">
+	Below, one entry is shown for the first occurrence of each unique
+	invalid character in your CSV. The invalid characters here have been
+	replaced with �, but may look different in your file on your machine.
+      </p>
+      <p class="content">
+        Each entry below displays the text immediately before and after the
+	invalid character, so you can more easily identify each invalid
+	character in your file. This contextual text may contain other invalid
+	characters, also replaced with �. The invalid character whose first
+	occurrence is captured in the entry will be the middle character of the
+	entry, unless the it occurs very close to the beginning or end of your
+	file.
+      </p>
+      <p class="content">
+	Once you identify the invalid character represented in each entry below,
+	find/replace all instances of the invalid character in your file.
+      </p>
+      <p class="content">
+	Note that the context shown may stretch across columns, may show the ","
+	column delimiter, or may show line breaks. Opening your CSV as a text
+	file in Notepad or other text editor will show you something closer to
+	what is in the entries below. Just remember that the valid UTF-8 �
+	character in the entries below is always a substitute for some other
+	invalid character in your CSV.
+      </p>
+	<ul>
+	<% flash[:csv_lint_invalid_encoding].split('|||').each do |err| %>
+	  <li>🔴 <%= err %></li>
+	<% end %>
+	</ul>
+    </div>
+  </article>
+<% end %>
+
 <% if flash[:csv_too_long] %>
   <article class="flash message is-danger is-small mt-3">
     <div class="message-header">

--- a/test/controllers/batches_controller_test.rb
+++ b/test/controllers/batches_controller_test.rb
@@ -16,6 +16,40 @@ class BatchesControllerTest < ActionDispatch::IntegrationTest
     @invalid_params = @valid_params.dup
   end
 
+  test 'cannot create batch with CSV found invalid by Csvlint' do
+    @invalid_params[:spreadsheet] =
+      fixture_file_upload('files/csvlint_invalid.csv', 'text/csv')
+
+    assert_no_difference('Batch.count') do
+      post batches_url, params: { batch: @invalid_params }
+    end
+    assert(flash.keys.include?('csv_lint'), 'Expected flash[:csv_lint]')
+    assert_redirected_to new_batch_path
+  end
+
+  test 'cannot create batch with CSV with invalid encoding' do
+    @invalid_params[:spreadsheet] =
+      fixture_file_upload('files/invalid_encoding.csv', 'text/csv')
+
+    assert_no_difference('Batch.count') do
+      post batches_url, params: { batch: @invalid_params }
+    end
+    assert(flash.keys.include?('invalid_encoding'),
+           'Expected flash[:invalid_encoding]')
+    assert_redirected_to new_batch_path
+  end
+
+  test 'cannot create batch with CSV with bad final EOL char(s)' do
+    @invalid_params[:spreadsheet] =
+      fixture_file_upload('files/crlf_eol_final_cr_eol.csv', 'text/csv')
+
+    assert_no_difference('Batch.count') do
+      post batches_url, params: { batch: @invalid_params }
+    end
+    assert(flash.keys.include?('last_row_eol'), 'Expected flash[:last_row_eol]')
+    assert_redirected_to new_batch_path
+  end
+
   test 'a user can view batches' do
     assert_can_view(batches_path)
   end
@@ -70,17 +104,20 @@ class BatchesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should not create a batch with malformed csv' do
-    @invalid_params[:spreadsheet] = fixture_file_upload('files/malformed.csv', 'text.csv')
+    @invalid_params[:spreadsheet] =
+      fixture_file_upload('files/malformed.csv', 'text.csv')
     assert_no_difference('Batch.count') do
       post batches_url, params: { batch: @invalid_params }
     end
   end
 
   test 'should not create a batch with greater than max limit csv' do
-    @invalid_params[:spreadsheet] = fixture_file_upload('files/too_large.csv', 'text.csv')
+    @invalid_params[:spreadsheet] =
+      fixture_file_upload('files/too_large.csv', 'text.csv')
     assert_no_difference('Batch.count') do
       post batches_url, params: { batch: @invalid_params }
     end
+    assert(flash.keys.include?('csv_too_long'), 'Expected flash[:csv_too_long]')
   end
 
   test 'should not create a batch with malformed json' do

--- a/test/fixtures/files/crlf_eol_final_cr_eol.csv
+++ b/test/fixtures/files/crlf_eol_final_cr_eol.csv
@@ -1,0 +1,3 @@
+obj,note
+val,val
+val,val

--- a/test/fixtures/files/csvlint_invalid.csv
+++ b/test/fixtures/files/csvlint_invalid.csv
@@ -1,0 +1,4 @@
+obj,note
+val,val
+val,val
+

--- a/test/fixtures/files/invalid_encoding.csv
+++ b/test/fixtures/files/invalid_encoding.csv
@@ -1,0 +1,4 @@
+obj,note
+val •,val
+val,val
+

--- a/test/services/invalid_character_finder_test.rb
+++ b/test/services/invalid_character_finder_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class InvalidCharacterFinderTest < ActiveSupport::TestCase
+  test 'can return invalid characters in context' do
+    str = <<~STR
+      Nis\x95i mihi \x95Phaedrum, inquam, tu mentitum aut Zenonem putas,
+      quorum utrumque audivi, cum mihi nihil sane praeter sedulitatem
+      probarent, omnes mihi Epicuri sententiae satis notae sunt. atque
+      eos, quos nominavi, cum Attico \x81 nostro frequenter audivi, cum
+      miraretur ille quidem utrumque, Phaedrum autem etiam amaret,
+      cotidieque inter nos ea, quae audiebamus, conferebamus, neque erat
+      umquam controversia, quid ego intellegerem, sed quid prob\x85arem.
+    STR
+
+    result = InvalidCharacterFinder.new(str.chomp).call
+    expected = [
+      'Nis�i mihi �Phaedrum, in',
+      'ominavi, cum Attico � nostro frequenter a',
+      'gerem, sed quid prob�arem.'
+    ]
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
[Improve error message for invalid character encoding in CSV](https://github.com/collectionspace/collectionspace-csv-importer/pull/215/commits/0e1b7e4c610fee84f622c1750c8972c8edc6539f)
[0e1b7e4](https://github.com/collectionspace/collectionspace-csv-importer/pull/215/commits/0e1b7e4c610fee84f622c1750c8972c8edc6539f)

- As long as CSV is getting invalid_encoding error(s), only the new
message will be shown. This is because encoding errors sometimes cause
structural errors that cascade through the file, causing hundreds of
error messages about structure in which the message about encoding
gets lost. Often if the encoding is fixed, the structural errors
disappear. This makes it obvious/clear that fixing the invalid
character encoding is the required.
- Shows the first occurrence of each invalid character in context, so
users can more easily find/fix the issues

[Show errors for Csvlint-valid files CSV library can't parse](https://github.com/collectionspace/collectionspace-csv-importer/pull/215/commits/6b3586f2bc4cc3f8223410734df313ac7e33e0d2)
[6b3586f](https://github.com/collectionspace/collectionspace-csv-importer/pull/215/commits/6b3586f2bc4cc3f8223410734df313ac7e33e0d2)

Resolves #213 
Currently, you are allowed to proceed to run the pre-processing job
with such a file, but the job fails when processing hits a row that
causes a CSV::MalformedCSVError. Unfortunately, this often occurs at
the very end of the file.

This commit adds a separate `csv_parse_validator_for(batch)` method
that is only called if Csvlint reports the file is valid.

CSV-Parsing the whole file before creating the batch may seem like
overkill, but (a) I can't come up with a better way to catch all
possible issues; and (b) it seems better than using system
resources/user time to pre-process a whole batch that is only going to
fail at the end.

Thinking forward: If we are eventually moving to using the database to
store information about each row and its state/status, then this step
can be reworked to serve a dual purpose: (1) prepare each row to be
added to database if we are able to prepare all rows successfully;
and (2) if not able to prepare all rows successfully, show error
messages and destroy batch.