### PR TITLE
Use collectionspace-mapper 6.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'aws-sdk-s3', require: false
 gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.15.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
-gem 'collectionspace-mapper', tag: 'v6.0.2', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v6.0.4', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
 
 gem 'csvlint',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: fe3b3faa4a2b6b56d8ff1aefd8d6211323f8b429
-  tag: v6.0.2
+  revision: 19ca4945dd5c397df061ec5e32492201b3327896
+  tag: v6.0.4
   specs:
-    collectionspace-mapper (6.0.2)
+    collectionspace-mapper (6.0.4)
       activesupport (= 6.0.4.7)
       chronic
       collectionspace-client (~> 0.15.0)


### PR DESCRIPTION
- 6.0.3 Absorbs exception raised when multiple records found when checking record status by id, and reports as a processing row error instead
- 6.0.4 Replaces limited case-insensitive fallback search with use of ILIKE (with no % qualifiers) operator for full case-insensitivity