### PR TITLE
Use collectionspace-mapper v6.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'aws-sdk-s3', require: false
 gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', tag: 'v0.15.1', git: 'https://github.com/collectionspace/collectionspace-client.git'
-gem 'collectionspace-mapper', tag: 'v6.0.4', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v6.1.0', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
 
 gem 'csvlint',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: 19ca4945dd5c397df061ec5e32492201b3327896
-  tag: v6.0.4
+  revision: dba3fc46d869e44dccc7e37b7c4bc2fe2d12be8e
+  tag: v6.1.0
   specs:
-    collectionspace-mapper (6.0.4)
+    collectionspace-mapper (6.1.0)
       activesupport (= 6.0.4.7)
       chronic
       collectionspace-client (~> 0.15.0)


### PR DESCRIPTION
Adds ability to import near duplicate authority terms without warnings by changing batch config setting.