### PR TITLE
Use csvlint v1.4.0.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collecti
 
 gem 'csvlint',
     git: 'https://github.com/lyrasis/csvlint.rb.git',
-    tag: 'v1.4.0'
+    tag: 'v1.4.0.6'
 gem 'devise'
 gem 'font-awesome-rails'
 # gem 'hiredis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,8 +36,8 @@ GIT
 
 GIT
   remote: https://github.com/lyrasis/csvlint.rb.git
-  revision: 8a589724d25e6a9caf4f3c916532cbbbc57d1603
-  tag: v1.4.0
+  revision: 26d071e2472eaf047505f421ae0e27014a3aada8
+  tag: v1.4.0.6
   specs:
     csvlint (1.4.0)
       activesupport
@@ -279,7 +279,7 @@ GEM
       chef-utils
     msgpack (1.4.5)
     multi_xml (0.6.0)
-    net-http-persistent (4.0.2)
+    net-http-persistent (4.0.5)
       connection_pool (~> 2.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -105,11 +105,6 @@ class BatchesController < ApplicationController
       #   line, when EOL char used elsewhere in file is CR
       if parsed.start_with?('New line must be')
         flash[:blank_rows] = true
-        # Catches extraneous EOL chars at end of final row that do not match
-        #   the EOL char used in the rest of the file, which Csvlint calls
-        #   calls valid, but that raise a malformed CSV error in the CSV library
-      elsif parsed.start_with?('Unquoted fields do not allow new line')
-        flash[:last_row_eol] = true
         # Catches any other malformed CSV errors raised by the CSV library, for
         #   files Csvlint called valid
       else

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -57,32 +57,6 @@
 </article>
 <% end %>
 
-<% if flash[:last_row_eol] %>
-<article class="flash message is-danger is-small mt-3">
-  <div class="message-header">
-    <p>CSV has invalid end-of-line character on last row</p>
-  </div>
-  <div class="message-body">
-    <p class="content">
-      The last row of your CSV ends with a line break that does not
-      match the line breaks used in the rest of the CSV file.
-      The easiest way to fix this is:
-    </p>
-      <ul>
-	<li>Open your CSV using a plain-text editor like Notepad or Notepad++</li>
-	<li>Go to the very end of the file</li>
-	<li>If your cursor can be put at the beginning of a blank line at the
-	  bottom of the file, backspace until the farthest your cursor can go is
-	  the end of the last line of data</li>
-      </ul>
-    <p class="content">
-      If you use Notepad++, the Edit &gt; EOL Conversion feature should also fix
-      this issue.
-    </p>
-  </div>
-</article>
-<% end %>
-
 <% if flash[:malformed_csv] %>
 <article class="flash message is-danger is-small mt-3">
   <div class="message-header">

--- a/test/controllers/batches_controller_test.rb
+++ b/test/controllers/batches_controller_test.rb
@@ -27,18 +27,6 @@ class BatchesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to new_batch_path
   end
 
-  test 'cannot create batch with CSV passed by Csvlint, but which'\
-       'blows up Ruby CSV library' do
-    @invalid_params[:spreadsheet] =
-      fixture_file_upload('files/crlf_eol_final_cr_eol.csv', 'text/csv')
-
-    assert_no_difference('Batch.count') do
-      post batches_url, params: { batch: @invalid_params }
-    end
-    assert(flash.keys.include?('last_row_eol'), 'Expected flash[:last_row_eol]')
-    assert_redirected_to new_batch_path
-  end
-
   test 'a user can view batches' do
     assert_can_view(batches_path)
   end

--- a/test/fixtures/files/crlf_eol_final_cr_eol.csv
+++ b/test/fixtures/files/crlf_eol_final_cr_eol.csv
@@ -1,3 +1,0 @@
-obj,note
-val,val
-val,val


### PR DESCRIPTION
v1.4.0.6 = post-merge of PR#6 in lyrasis fork.

This update fixes the problem of the row count of CSVs with \r EOL always being set to 1, which causes CSV Importer to calculate ridiculously huge percent done values as it processes all the actual rows. 

The changes to csvlint mean none of my test CSVs now trigger the situation handled/tested by the removed code. The specific situation handled is now reported as invalid by csvlint, so we don't need to have specific handling for it in this application.