### PR TITLE
Validate connection on Preprocess step

### DIFF
--- a/app/models/step/preprocess.rb
+++ b/app/models/step/preprocess.rb
@@ -2,8 +2,10 @@
 
 module Step
   class Preprocess < ApplicationRecord
+    include ConnectionStatus
     include WorkflowMetadata
     belongs_to :batch
+    validate :connection_is_active?
 
     def name
       :preprocessing


### PR DESCRIPTION
Connection authentication check was added to all workflow steps in [PR 200](https://github.com/collectionspace/collectionspace-csv-importer/pull/200), but removed (kept in only the processing and transferring steps) as part of refactoring/cleanup in [PR 204](https://github.com/collectionspace/collectionspace-csv-importer/pull/204).

This PR adds this check back to the preprocessing step, on the principle of saving the user time and effort. They should find out about an unusable connection to CollectionSpace ASAP when starting on a batch. If that's not at batch creation time, then it should be in the preprocessing step.

Resolves #226 