### PR TITLE
Bump mapper version and fix error message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'aws-sdk-s3', require: false
 gem 'bulma-rails', '~> 0.9.0'
 
 gem 'collectionspace-client', '>= 1.0.0'
-gem 'collectionspace-mapper', tag: 'v6.1.1', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v6.1.2', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 gem 'collectionspace-refcache', tag: 'v1.0.0', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
 
 gem 'csvlint',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: 688756c8ef006d780218726ff234a2a294372232
-  tag: v6.1.1
+  revision: 7f23789f7a5ca84f9bf6c3a4b6ecb4d73f9d52ba
+  tag: v6.1.2
   specs:
-    collectionspace-mapper (6.1.1)
+    collectionspace-mapper (6.1.2)
       activesupport (= 6.0.4.7)
       chronic
       collectionspace-refcache
@@ -482,7 +482,7 @@ GEM
     wmi-lite (1.0.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    xxhash (0.6.0)
+    xxhash (0.7.0)
     zache (0.12.0)
     zeitwerk (2.6.13)
 

--- a/app/jobs/process_job.rb
+++ b/app/jobs/process_job.rb
@@ -79,9 +79,11 @@ class ProcessJob < ApplicationJob
                      header: 'ERR: mapper',
                      message: 'Mapper did not return result for unexpected '\
                               'reason. Please send a copy of this report to '\
-                              'collectionspace@lyrasis.org. We will use the '\
-                              'following info to diagnose and fix the '\
-                              'problem, but you may ignore it: '\
+                              'the Lyrasis help desk (hosted users) or your '\
+                              'recommended support channel. Please do NOT '\
+                              'delete the batch where you got this error. '\
+                              'We will use the following info to diagnose '\
+                              'and fix the problem, but you may ignore it: '\
                               "#{e.message} -- #{e.backtrace.first}" })
     @manager.add_message('Mapping failed for one or more records')
     nil


### PR DESCRIPTION
1. Bumps collectionspace-mapper to a new bugfix version to fix ZD26342
2. Stop instructing people to email the Program team when there's an unexpected processing error. 